### PR TITLE
ci: use binding-directory instead of binding-path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,23 +87,23 @@ jobs:
       - name: Download rspack binding
         uses: rspack-contrib/rspack-toolchain/download-rspack-binding@main
         with:
-          path: ${{ steps.napi-info.outputs.binding-path }}/artifacts
+          path: ${{ steps.napi-info.outputs.binding-directory }}/artifacts
 
       - name: List artifacts
         run: ls -R artifacts
-        working-directory: ${{ steps.napi-info.outputs.binding-path }}
+        working-directory: ${{ steps.napi-info.outputs.binding-directory }}
 
       - name: Create npm dirs
         run: pnpm napi create-npm-dirs
-        working-directory: ${{ steps.napi-info.outputs.binding-path }}
+        working-directory: ${{ steps.napi-info.outputs.binding-directory }}
 
       - name: Move artifacts
         run: pnpm napi artifacts
-        working-directory: ${{ steps.napi-info.outputs.binding-path }}
+        working-directory: ${{ steps.napi-info.outputs.binding-directory }}
 
       - name: List npm dirs
         run: ls -R npm
-        working-directory: ${{ steps.napi-info.outputs.binding-path }}
+        working-directory: ${{ steps.napi-info.outputs.binding-directory }}
 
       - name: Create npm token
         run: |
@@ -116,7 +116,7 @@ jobs:
           npm config set access public
           npm config set provenance true
           pnpm napi pre-publish --no-gh-release -t npm
-        working-directory: ${{ steps.napi-info.outputs.binding-path }}
+        working-directory: ${{ steps.napi-info.outputs.binding-directory }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,16 +31,16 @@ jobs:
         uses: rspack-contrib/rspack-toolchain/download-rspack-binding@main
         with:
           target: ${{ matrix.target }}
-          path: ${{ steps.napi-info.outputs.binding-path }}
+          path: ${{ steps.napi-info.outputs.binding-directory }}
 
       - name: Show binding
         shell: bash
         run: |
           echo "Contents of binding directory:"
-          ls -la ${{ steps.napi-info.outputs.binding-path }}
+          ls -la ${{ steps.napi-info.outputs.binding-directory }}
           echo ""
           echo "*.node files:"
-          find ${{ steps.napi-info.outputs.binding-path }} -name "*.node" -type f -exec ls -la {} \; || echo "No .node files found"
+          find ${{ steps.napi-info.outputs.binding-directory }} -name "*.node" -type f -exec ls -la {} \; || echo "No .node files found"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
See: https://github.com/rspack-contrib/rspack-toolchain/commit/bb8058404b609201c4c09cd8b205d6b70a24d60f