### PR TITLE
chore: release v0.0.2

### DIFF
--- a/crates/binding/package.json
+++ b/crates/binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack-template/binding",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.2",
   "homepage": "https://github.com/rspack-contrib/rspack-binding-template",
   "bugs": {
     "url": "https://github.com/rspack-contrib/rspack-binding-template/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack-template/core",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.2",
   "homepage": "https://github.com/rspack-contrib/rspack-binding-template",
   "bugs": {
     "url": "https://github.com/rspack-contrib/rspack-binding-template/issues"


### PR DESCRIPTION
## What's Changed
* chore(deps): update dependency @types/node to v24.0.15 by @renovate[bot] in https://github.com/rspack-contrib/rspack-binding-template/pull/15
* chore(deps): lock file maintenance by @renovate[bot] in https://github.com/rspack-contrib/rspack-binding-template/pull/16
* feat(template): add dts typings by @h-a-n-a in https://github.com/rspack-contrib/rspack-binding-template/pull/17
* ci: use binding-directory instead of binding-path by @h-a-n-a in https://github.com/rspack-contrib/rspack-binding-template/pull/18
* chore: release v0.0.1-alpha.0 by @h-a-n-a in https://github.com/rspack-contrib/rspack-binding-template/pull/19
* chore(deps): update rspack dependencies by @renovate[bot] in https://github.com/rspack-contrib/rspack-binding-template/pull/20


**Full Changelog**: https://github.com/rspack-contrib/rspack-binding-template/compare/rspack@1.4.8...rspack@1.4.9