### PR TITLE
ci: resolve disk space error on GitHub Actions runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # Fix: Resolve disk space error "ENOSPC: no space left on device" on GitHub Actions runners
+      - name: Free disk cache
+        if: ${{ runner.environment == 'github-hosted' && inputs.target == 'x86_64-unknown-linux-gnu' }}
+        uses: xc2/free-disk-space@fbe203b3788f2bebe2c835a15925da303eaa5efe # v1.0.0
+        with:
+          tool-cache: false
+
       - name: Get NAPI info
         id: napi-info
         uses: rspack-contrib/rspack-toolchain/get-napi-info@v1


### PR DESCRIPTION
Fix: Resolve disk space error "ENOSPC: no space left on device" on GitHub Actions runners
    