### PR TITLE
fix: update github workflows and urls to use rstackjs organization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   build:
     name: Build
-    uses: rspack-contrib/rspack-toolchain/.github/workflows/build.yml@v1
+    uses: rstackjs/rspack-toolchain/.github/workflows/build.yml@v1
 
   test:
     name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rspack-contrib/rspack-toolchain/.github/workflows/build.yml@v1
+    uses: rstackjs/rspack-toolchain/.github/workflows/build.yml@v1
     with:
       napi-build-command: pnpm build --release
 
@@ -89,10 +89,10 @@ jobs:
 
       - name: Get NAPI info
         id: napi-info
-        uses: rspack-contrib/rspack-toolchain/get-napi-info@v1
+        uses: rstackjs/rspack-toolchain/get-napi-info@v1
 
       - name: Download rspack binding
-        uses: rspack-contrib/rspack-toolchain/download-rspack-binding@v1
+        uses: rstackjs/rspack-toolchain/download-rspack-binding@v1
         with:
           path: ${{ steps.napi-info.outputs.binding-directory }}/artifacts
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,10 @@ jobs:
 
       - name: Get NAPI info
         id: napi-info
-        uses: rspack-contrib/rspack-toolchain/get-napi-info@v1
+        uses: rstackjs/rspack-toolchain/get-napi-info@v1
 
       - name: Download rspack binding
-        uses: rspack-contrib/rspack-toolchain/download-rspack-binding@v1
+        uses: rstackjs/rspack-toolchain/download-rspack-binding@v1
         with:
           target: ${{ matrix.target }}
           path: ${{ steps.napi-info.outputs.binding-directory }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Quick Start
 
-📖 **[Create custom binding](https://rspack-contrib.github.io/rspack-rust-book/custom-binding/getting-started/index.html)**
+📖 **[Create custom binding](https://rstackjs.github.io/rspack-rust-book/custom-binding/getting-started/index.html)**
 
 ## Why?
 
@@ -21,7 +21,7 @@ _Rspack Custom Binding_ allows you to extend Rspack directly with native Rust co
 
 With custom binding, you can still use the familiar JavaScript API (`@rspack/core`), but your custom logic runs natively, combining the best of both worlds.
 
-Check out [rationale](https://rspack-contrib.github.io/rspack-rust-book/custom-binding/getting-started/rationale.html) for more details.
+Check out [rationale](https://rstackjs.github.io/rspack-rust-book/custom-binding/getting-started/rationale.html) for more details.
 
 ## Supported Platforms
 
@@ -42,4 +42,4 @@ Check out [rationale](https://rspack-contrib.github.io/rspack-rust-book/custom-b
 
 > **Note:** Node.js support requires >= 18.
 >
-> Multi-platform publishing and CI support is powered by [rspack-toolchain](https://github.com/rspack-contrib/rspack-toolchain). For the latest supported platforms, see the [official supported targets list](https://github.com/rspack-contrib/rspack-toolchain/tree/main?tab=readme-ov-file#supported-targets).
+> Multi-platform publishing and CI support is powered by [rspack-toolchain](https://github.com/rstackjs/rspack-toolchain). For the latest supported platforms, see the [official supported targets list](https://github.com/rstackjs/rspack-toolchain/tree/main?tab=readme-ov-file#supported-targets).

--- a/crates/binding/package.json
+++ b/crates/binding/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@rspack-template/binding",
   "version": "0.0.3",
-  "homepage": "https://github.com/rspack-contrib/rspack-binding-template",
+  "homepage": "https://github.com/rstackjs/rspack-binding-template",
   "bugs": {
-    "url": "https://github.com/rspack-contrib/rspack-binding-template/issues"
+    "url": "https://github.com/rstackjs/rspack-binding-template/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rspack-contrib/rspack-binding-template.git",
+    "url": "git+https://github.com/rstackjs/rspack-binding-template.git",
     "directory": "crates/binding"
   },
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@rspack-template/core",
   "version": "0.0.3",
-  "homepage": "https://github.com/rspack-contrib/rspack-binding-template",
+  "homepage": "https://github.com/rstackjs/rspack-binding-template",
   "bugs": {
-    "url": "https://github.com/rspack-contrib/rspack-binding-template/issues"
+    "url": "https://github.com/rstackjs/rspack-binding-template/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rspack-contrib/rspack-binding-template.git"
+    "url": "git+https://github.com/rstackjs/rspack-binding-template.git"
   },
   "packageManager": "pnpm@10.20.0",
   "main": "lib/index.js",


### PR DESCRIPTION
Update all references from rspack-contrib to rstackjs in CI workflows, package.json files, and documentation.