### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   build:
     name: Build
-    uses: rstackjs/rspack-toolchain/.github/workflows/build.yml@a0ff0d85e7dd792d5ed23c4d55f369e4b87aae87
+    uses: rstackjs/rspack-toolchain/.github/workflows/build.yml@c0b7f47d0d657adbc4fddb3b3f2b607019004491
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run cargo check
         run: cargo check --workspace
@@ -34,15 +34,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run cargo clippy
         run: cargo clippy --workspace -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rstackjs/rspack-toolchain/.github/workflows/build.yml@c3f79e76fda7e6fe057608da70fddcb5556bcdc6 # v1
+    uses: rstackjs/rspack-toolchain/.github/workflows/build.yml@c0b7f47d0d657adbc4fddb3b3f2b607019004491 # v1
     with:
       napi-build-command: pnpm build --release
 
@@ -89,10 +89,10 @@ jobs:
 
       - name: Get NAPI info
         id: napi-info
-        uses: rstackjs/rspack-toolchain/get-napi-info@a0ff0d85e7dd792d5ed23c4d55f369e4b87aae87
+        uses: rstackjs/rspack-toolchain/get-napi-info@c0b7f47d0d657adbc4fddb3b3f2b607019004491
 
       - name: Download rspack binding
-        uses: rstackjs/rspack-toolchain/download-rspack-binding@a0ff0d85e7dd792d5ed23c4d55f369e4b87aae87
+        uses: rstackjs/rspack-toolchain/download-rspack-binding@c0b7f47d0d657adbc4fddb3b3f2b607019004491
         with:
           path: ${{ steps.napi-info.outputs.binding-directory }}/artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    uses: rstackjs/rspack-toolchain/.github/workflows/build.yml@v1
+    uses: rstackjs/rspack-toolchain/.github/workflows/build.yml@c3f79e76fda7e6fe057608da70fddcb5556bcdc6 # v1
     with:
       napi-build-command: pnpm build --release
 
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Display release mode
         run: |
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 
@@ -70,7 +70,7 @@ jobs:
         run: corepack prepare
 
       - name: Cache pnpm dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Get NAPI info
         id: napi-info
@@ -44,7 +44,7 @@ jobs:
           find ${{ steps.napi-info.outputs.binding-directory }} -name "*.node" -type f -exec ls -la {} \; || echo "No .node files found"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 
@@ -55,7 +55,7 @@ jobs:
         run: corepack prepare
 
       - name: Cache pnpm dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,10 @@ jobs:
 
       - name: Get NAPI info
         id: napi-info
-        uses: rstackjs/rspack-toolchain/get-napi-info@a0ff0d85e7dd792d5ed23c4d55f369e4b87aae87
+        uses: rstackjs/rspack-toolchain/get-napi-info@c0b7f47d0d657adbc4fddb3b3f2b607019004491
 
       - name: Download rspack binding
-        uses: rstackjs/rspack-toolchain/download-rspack-binding@a0ff0d85e7dd792d5ed23c4d55f369e4b87aae87
+        uses: rstackjs/rspack-toolchain/download-rspack-binding@c0b7f47d0d657adbc4fddb3b3f2b607019004491
         with:
           target: ${{ matrix.target }}
           path: ${{ steps.napi-info.outputs.binding-directory }}


### PR DESCRIPTION
- Pin GitHub Actions workflow dependencies to full commit SHAs for better supply-chain security.
- Preserve original version refs as comments for easier future maintenance.
- Keep existing already-pinned `rspack-toolchain` action references unchanged.